### PR TITLE
fix(api-server): Fix slack text regex

### DIFF
--- a/api/api/controllers/feedback.js
+++ b/api/api/controllers/feedback.js
@@ -47,12 +47,14 @@ function addFeedbackWithJson(req, res) {
 
 function feedbackParamsFromSlackPayload(slackPayload) {
   const FEEDBACK_REGEX = {
-    RECEIVER: /^<@(\w+)\|?(\w+)>{1}/g,
+
+    RECEIVER: /^<@(\w+)\|{1}([a-z0-9._-])+>{1}/g,
     TYPE: /(?: +\:\) +)|(?: +\:\( +)/g,
     MESSAGE: /((?: +\:\) +)|(?: +\:\( +))(.{1,140})/g
   };
-
   const receiverMatch = FEEDBACK_REGEX.RECEIVER.exec(slackPayload.text);
+  console.info("receiverMatch");
+  console.info(receiverMatch);
   const receiverId = receiverMatch[1];
   const receiverName = receiverMatch[2];
   const type = slackPayload.text.match(FEEDBACK_REGEX.TYPE)[0].trim();

--- a/api/api/swagger/swagger.yaml
+++ b/api/api/swagger/swagger.yaml
@@ -135,7 +135,7 @@ paths:
                 description: Text sent by the Slack user. It should contain one user mention and one :) or :( – Also, the stripped-off message should not be longer than 140 characters.
                 type: string
                 format: slackCommand
-                pattern: "^(<@\\w+\\|?\\w+>{1})\\s?((?: +\\:\\) +)|(?: +\\:\\( +))(.{1,140})"
+                pattern: "^(<@\\w+\\|{1}(?:[a-z0-9._-])+>{1})\\s?((?: +\\:\\) +)|(?: +\\:\\( +))(.{1,140})"
                 example: "<@U012ABCDEF|leo> :( don't wake me up at night anymore please!!"
               response_url:
                 description: "URL to respond in case you want to provide additional command response messages, or if you're unable to immediately respond to a command within 3000 milliseconds, use the specific `response_url`"


### PR DESCRIPTION
Regex for slack text was not matching usernames with dots.
This fixes the Regex in swagger spec and the one used to build the API payload